### PR TITLE
Fix issue with itemstack casting

### DIFF
--- a/src/org/getspout/spout/SpoutNetServerHandler.java
+++ b/src/org/getspout/spout/SpoutNetServerHandler.java
@@ -337,10 +337,10 @@ public class SpoutNetServerHandler extends NetServerHandler {
 	                
 	                if (event.isCancelled()) {
 	                    player.setLevel(level);
-	                    table.a.setItem(0, ((SpoutCraftItemStack) event.getBefore()).getHandle());
+	                    table.a.setItem(0, initial);
 	                } else {
 	                    player.setLevel(event.getLevelAfter());
-	                    table.a.setItem(0, ((SpoutCraftItemStack) event.getResult()).getHandle());
+	                    table.a.setItem(0, SpoutCraftItemStack.createNMSItemStack(event.getResult()));
 	                }
 	            }
 	            this.player.activeContainer.a();


### PR DESCRIPTION
API/Code is under the SpoutDev License and can be used accordingly.
