### PR TITLE
Fixed #1237 Interacting with Blocks Places Custom Blocks Unexpectedly

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutPlayerListener.java
+++ b/src/main/java/org/getspout/spout/SpoutPlayerListener.java
@@ -122,11 +122,32 @@ public class SpoutPlayerListener extends PlayerListener {
 		SpoutCraftPlayer player = (SpoutCraftPlayer) SpoutCraftPlayer.getPlayer(event.getPlayer());
 
 		if (event.getClickedBlock() != null) {
-			Material type = event.getClickedBlock().getType();
 			boolean action = false;
-			if (type == Material.CHEST || type == Material.DISPENSER || type == Material.WORKBENCH || type == Material.FURNACE) {
-				player.getNetServerHandler().activeLocation = event.getClickedBlock().getLocation();
-				action = true;
+			
+			switch (event.getClickedBlock().getType()) {
+				case BREWING_STAND:
+				case CHEST:
+				case DISPENSER:
+				case ENCHANTMENT_TABLE:
+				case FURNACE:
+				case WORKBENCH:
+					player.getNetServerHandler().activeLocation = event.getClickedBlock().getLocation();
+					action = true;
+					break;
+				case BED_BLOCK:
+				case CAKE_BLOCK:
+				case CAULDRON:
+				case DIODE_BLOCK_OFF:
+				case DIODE_BLOCK_ON:
+				case FENCE_GATE:
+				case IRON_DOOR_BLOCK:
+				case LEVER:
+				case NOTE_BLOCK:
+				case STONE_BUTTON:
+				case TRAP_DOOR:
+				case WOODEN_DOOR:
+					action = true;
+					break;
 			}
 
 			if (event.hasItem() && !action) {
@@ -138,7 +159,7 @@ public class SpoutPlayerListener extends PlayerListener {
 
 				ItemStack item = event.getItem();
 				int damage = item.getDurability();
-				if (item.getType() == Material.FLINT && damage != 0 && !action) {
+				if (item.getType() == Material.FLINT && damage != 0) {
 
 				SimpleMaterialManager mm = (SimpleMaterialManager)SpoutManager.getMaterialManager();
 


### PR DESCRIPTION
Should fix all cases where players are interacting with a block.

Does not fix placing custom blocks at torches and other blocks where vanilla blocks cannot be placed.

https://github.com/SpoutDev/Spout/issues/1237
