### PR TITLE
InventoryCraftEvent extended to contain ResultAmount

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutNetServerHandler.java
+++ b/src/main/java/org/getspout/spout/SpoutNetServerHandler.java
@@ -354,6 +354,7 @@ public class SpoutNetServerHandler extends NetServerHandler {
 				if (inventory instanceof CraftingInventory) {
 					CraftingInventory crafting = (CraftingInventory) inventory;
 					InventoryCrafting recipe = null;
+					int amount = 1;
 					if (inventory instanceof SpoutCraftingInventory) {
 						recipe = ((SpoutCraftingInventory) crafting).getMatrixHandle();
 					} else {
@@ -375,7 +376,15 @@ public class SpoutNetServerHandler extends NetServerHandler {
 					}
 					// Clicking to grab the crafting result
 					if (type == InventorySlotType.RESULT) {
-						InventoryCraftEvent craftEvent = new InventoryCraftEvent(this.getPlayer(), crafting, this.activeLocation, type, packet.b, matrix, craftResult, cursor, packet.c == 0, packet.f);
+						if (packet.f) {
+							amount = 64;
+							for (ItemStack i : crafting.getMatrix()) {
+								if (i != null && i.getTypeId() > 0 && i.getAmount() < amount) {
+									amount = i.getAmount();
+								}
+							}
+						}
+						InventoryCraftEvent craftEvent = new InventoryCraftEvent(this.getPlayer(), crafting, this.activeLocation, type, packet.b, matrix, craftResult, amount, cursor, packet.c == 0, packet.f);
 						Bukkit.getServer().getPluginManager().callEvent(craftEvent);
 						craftEvent.getInventory().setResult(craftEvent.getResult());
 						cursor = SpoutCraftItemStack.getCraftItemStack(craftEvent.getCursor());


### PR DESCRIPTION
While crafting with the shift click method, there is more than one of the item crafted. This is of high importance for things like statistics, to know how many items exactly were produced. With this commit, it finds the smallest Stack in the crafting matrix as this is the number of Result Stacks being produced, then passing this number to the Event.
