### PR TITLE
fixes placing and destroying of custom blocks with custom vanilla block ID/block metadata

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutBlockListener.java
+++ b/src/main/java/org/getspout/spout/SpoutBlockListener.java
@@ -56,9 +56,6 @@ public class SpoutBlockListener implements Listener {
 		}
 
 		SpoutBlock block = (SpoutBlock) event.getBlock();
-		if (block.getType() != Material.STONE && block.getType() != Material.GLASS) {
-			return;
-		}
 
 		SpoutPlayer player = (SpoutPlayer)event.getPlayer();
 

--- a/src/main/java/org/getspout/spout/SpoutPlayerListener.java
+++ b/src/main/java/org/getspout/spout/SpoutPlayerListener.java
@@ -177,7 +177,7 @@ public class SpoutPlayerListener implements Listener {
 						CustomBlock cb = MaterialData.getCustomBlock(damage);
 						if (cb != null) {
 							BlockState oldState = block.getState();
-							block.setTypeIdAndData(cb.getBlockId(), (byte)(0), true);
+							block.setTypeIdAndData(cb.getBlockId(), (byte)(cb.getBlockData()), true);
 							cb.onBlockPlace(block.getWorld(), block.getX(), block.getY(), block.getZ(), player);
 							mm.overrideBlock(block, cb);
 


### PR DESCRIPTION
This fixes placing and destroying of custom blocks with custom vanilla block ID/block metadata to work properly with the new SpoutPluginAPI changes.

The SpoutPluginAPI pull request is essential: https://github.com/SpoutDev/SpoutPluginAPI/pull/14
