### PR TITLE
Removed the normal click handling when the event's result is set to Result.ALLOW

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutNetServerHandler.java
+++ b/src/main/java/org/getspout/spout/SpoutNetServerHandler.java
@@ -477,33 +477,6 @@ public class SpoutNetServerHandler extends NetServerHandler {
 				if (packet.b == -999) { // Clicked outside, just defer to default
 					itemstack = this.player.activeContainer.a(packet.b, packet.c, packet.f, this.player);
 				} else {
-					if (click == LEFT_CLICK && (itemstack != null && cursorstack != null && itemstack.doMaterialsMatch(cursorstack))) {
-						// Left-click full slot with full cursor of same item; merge stacks
-						itemstack.count += cursorstack.count;
-						cursorstack = null;
-					} else if (click == LEFT_CLICK || (itemstack != null && cursorstack != null && !itemstack.doMaterialsMatch(cursorstack))) {
-						// Either left-click, or right-click full slot with full cursor of different item; just swap contents
-						ItemStack temp = itemstack;
-						itemstack = cursorstack;
-						cursorstack = temp;
-					} else if (click == RIGHT_CLICK) { // Right-click with either slot or cursor empty
-						if (itemstack == null) { // Slot empty; drop one
-							if (cursorstack != null) {
-								itemstack = cursorstack.a(1);
-								if (cursorstack.count == 0) {
-									cursorstack = null;
-								}
-							}
-						} else if (cursorstack == null) { // Cursor empty; take half
-							cursorstack = itemstack.a((itemstack.count + 1) / 2);
-						} else { // Neither empty, but same item; drop one
-							ItemStack drop = cursorstack.a(1);
-							itemstack.count += drop.count;
-							if (cursorstack.count == 0) {
-								cursorstack = null;
-							}
-						}
-					}
 					// update the stacks
 					setActiveSlot(packet.b, itemstack);
 					setCursorSlot(cursorstack);


### PR DESCRIPTION
As I said here : https://github.com/SpoutDev/Spout/issues/1627#issuecomment-4193127.

Setting the InventoryClickEvent's result to Result.ALLOW should mean that the results of the click are not behaving the same way as Minecraft does. 
Therefore, its handling should be manual, not assisted in any ways by the netServerHandler, as it would end in having unexpected results 
The actual code simulates a normal click before updating the stacks, and as such, will never create the expected result if you set manually the cursor and the clicked stack - which is the whole point of setting the result to ALLOW.
