### PR TITLE
onBlockDestroyed gets called in CustomBlock - no need to call the method twice!

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutBlockListener.java
+++ b/src/main/java/org/getspout/spout/SpoutBlockListener.java
@@ -61,7 +61,6 @@ public class SpoutBlockListener implements Listener {
 
 		if (block.isCustomBlock()) {
 			CustomBlock material = block.getCustomBlock();
-			material.onBlockDestroyed(block.getWorld(), block.getX(), block.getY(), block.getZ(), player);
 			if (material.getItemDrop() != null) {
 				if (player.getGameMode() == GameMode.SURVIVAL) {
 					block.getWorld().dropItem(block.getLocation(), material.getItemDrop());


### PR DESCRIPTION
The method gets called twice currently - I removed one instance.
