### PR TITLE
Containers can be used as a backing for custom blocks.

### DIFF
--- a/src/main/java/org/getspout/spout/InventoryListener.java
+++ b/src/main/java/org/getspout/spout/InventoryListener.java
@@ -31,12 +31,14 @@ public class InventoryListener implements Listener{
 
 	@EventHandler
 	public void onInventoryClose(InventoryCloseEvent event) {
+		@SuppressWarnings("deprecation")
 		org.getspout.spoutapi.event.inventory.InventoryCloseEvent spoutEvent = new org.getspout.spoutapi.event.inventory.InventoryCloseEvent((Player) event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory());
 		Bukkit.getServer().getPluginManager().callEvent(spoutEvent);
 	}
 	
 	@EventHandler
 	public void onInventoryOpen(InventoryOpenEvent event) {
+		@SuppressWarnings("deprecation")
 		org.getspout.spoutapi.event.inventory.InventoryOpenEvent spoutEvent = new org.getspout.spoutapi.event.inventory.InventoryOpenEvent((Player) event.getPlayer(), event.getView().getTopInventory(), event.getView().getBottomInventory());
 		spoutEvent.setCancelled(event.isCancelled());
 		Bukkit.getServer().getPluginManager().callEvent(spoutEvent);

--- a/src/main/java/org/getspout/spout/PluginListener.java
+++ b/src/main/java/org/getspout/spout/PluginListener.java
@@ -30,6 +30,7 @@ public class PluginListener implements Listener {
 		Bukkit.getPluginManager().registerEvents(this, plugin);
 	}
 	
+	@SuppressWarnings("deprecation")
 	@EventHandler
 	public void onPluginDisable(PluginDisableEvent event) {
 		SpoutManager.getKeyboardManager().removeAllKeyBindings(event.getPlugin());

--- a/src/main/java/org/getspout/spout/block/SpoutCraftBlock.java
+++ b/src/main/java/org/getspout/spout/block/SpoutCraftBlock.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.craftbukkit.CraftChunk;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.block.CraftBlock;

--- a/src/main/java/org/getspout/spout/player/SpoutCraftPlayer.java
+++ b/src/main/java/org/getspout/spout/player/SpoutCraftPlayer.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import net.minecraft.server.ChunkCoordIntPair;
 import net.minecraft.server.ContainerPlayer;
 import net.minecraft.server.Entity;
 import net.minecraft.server.EntityPlayer;


### PR DESCRIPTION
I copied the custom block handling code to the CustomContainer class allowing for custom blocks to use CustomContainers as a backing material. This should probably done for the other special case overrides, but there seems to be no rationale for why someone would want to make a custom block with them as a backing.

The issue with just copying over the code is that should any modifications occur, they would need to be put in every class. If recommended, I can create an additional class that all CustomBlocks will delegate to.

I also got rid of most of the warnings eclipse found by adding in SuppressWarnings("deprecation") where needed and removing unused imports.
