### PR TITLE
Fixed doors not to ignore left-clicks. This fixes #Spoutplugin-9

### DIFF
--- a/src/main/java/org/getspout/spout/block/mcblock/CustomDoor.java
+++ b/src/main/java/org/getspout/spout/block/mcblock/CustomDoor.java
@@ -254,7 +254,7 @@ public class CustomDoor extends BlockDoor implements CustomMCBlock {
 			SpoutCraftPlayer player = (SpoutCraftPlayer) SpoutManager.getPlayer((Player) ((EntityPlayer) entityhuman).getBukkitEntity());
 			player.setLastClickedLocation(new Location(player.getWorld(), i, j, k));
 		}
-		parent.b(world, i, j, k, entityhuman);
+		parent.attack(world, i, j, k, entityhuman);
 	}
 
 	@Override


### PR DESCRIPTION
Fixed doors not to ignore left-clicks.  ("invisible wall bug")
This fixes #SPOUTPLUGIN-9

Signed-off-by: steffen steffenb198@aol.com
