### PR TITLE
Allow bindings for mouse clicks.

### DIFF
--- a/src/main/java/org/getspout/spoutapi/keyboard/Keyboard.java
+++ b/src/main/java/org/getspout/spoutapi/keyboard/Keyboard.java
@@ -148,6 +148,9 @@ public enum Keyboard {
 	KEY_POWER(222),
 	KEY_SLEEP(223),
 	KEYBOARD_SIZE(256),
+	MOUSE_RIGHT(-99),
+	MOUSE_LEFT(-100),
+	MOUSE_MIDDLE(-98),
 	KEY_UNKNOWN(-1);
 	private final int keyCode;
 	private static final Map<Integer, Keyboard> lookupKeyCode = new HashMap<Integer, Keyboard>();


### PR DESCRIPTION
Extended keyboard enum to be able to register mouse bindings.

Signed-off-by: Robert Klassert robert.klassert@arcor.de

Merged from SpoutPluginAPI-UNUSED
