### PR TITLE
Fixed SpoutCraftPlayer.hashCode to use lowercase name.

### DIFF
--- a/src/main/java/org/getspout/spout/player/SpoutCraftPlayer.java
+++ b/src/main/java/org/getspout/spout/player/SpoutCraftPlayer.java
@@ -202,7 +202,7 @@ public class SpoutCraftPlayer extends CraftPlayer implements SpoutPlayer {
 	@Override
 	public int hashCode() {
 		int hash = 5;
-		hash = 97 * hash + (this.getName() != null ? this.getName().hashCode() : 0);
+		hash = 97 * hash + (this.getName() != null ? this.getName().toLowerCase().hashCode() : 0);
 		return hash;
 	}
 


### PR DESCRIPTION
CraftBukkit changed this.

Signed-off-by: Ross Allan rallanpcl@gmail.com
