### PR TITLE
Fix CustomBlock.onBlockDestroyed(world, x, y, z, player)

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutBlockListener.java
+++ b/src/main/java/org/getspout/spout/SpoutBlockListener.java
@@ -63,6 +63,7 @@ public class SpoutBlockListener implements Listener {
 
 		if (block.getCustomBlock() != null) {
 			CustomBlock material = block.getCustomBlock();
+			material.onBlockDestroyed(block.getWorld(), block.getX(), block.getY(), block.getZ(), player);
 			if (material.getItemDrop() != null) {
 				if (player.getGameMode() == GameMode.SURVIVAL) {
 					block.getWorld().dropItem(block.getLocation(), material.getItemDrop());


### PR DESCRIPTION
Revert "onBlockDestroyed gets called in CustomBlock - no need to call the method twice!"

This reverts commit 86c0325e47844e83aa03746b16d4a2878b3f3177.

This was incorrect - there were two onBlockDestroyed methods with different signatures, so removing this resulted in onBlockDestroyed with a player argument never being called.
