### PR TITLE
Custom Item Texture Caching when using textures from file instead of URL

### DIFF
--- a/src/main/java/org/getspout/spout/inventory/SimpleMaterialManager.java
+++ b/src/main/java/org/getspout/spout/inventory/SimpleMaterialManager.java
@@ -19,13 +19,13 @@
  */
 package org.getspout.spout.inventory;
 
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.List;
-
 import gnu.trove.list.array.TByteArrayList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TIntObjectHashMap;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
 
 import net.minecraft.server.Item;
 
@@ -35,12 +35,9 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.plugin.Plugin;
-
 import org.getspout.spout.block.SpoutCraftBlock;
 import org.getspout.spout.player.SpoutCraftPlayer;
-import org.getspout.spoutapi.Spout;
 import org.getspout.spoutapi.SpoutManager;
-import org.getspout.spoutapi.block.SpoutChunk;
 import org.getspout.spoutapi.block.SpoutChunk;
 import org.getspout.spoutapi.inventory.ItemMap;
 import org.getspout.spoutapi.inventory.MaterialManager;

--- a/src/main/java/org/getspout/spout/player/SpoutCraftPlayer.java
+++ b/src/main/java/org/getspout/spout/player/SpoutCraftPlayer.java
@@ -27,7 +27,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import net.minecraft.server.ContainerPlayer;
 import net.minecraft.server.Entity;
@@ -62,7 +61,6 @@ import org.bukkit.permissions.PermissionAttachment;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.Vector;
-
 import org.getspout.spout.PacketCompressionThread;
 import org.getspout.spout.Spout;
 import org.getspout.spout.SpoutNetServerHandler;

--- a/src/main/java/org/getspout/spout/sound/SimpleSoundManager.java
+++ b/src/main/java/org/getspout/spout/sound/SimpleSoundManager.java
@@ -223,7 +223,7 @@ public class SimpleSoundManager implements SoundManager {
 				throw new UnsupportedOperationException("All Url's must be between 5 and 256 characters");
 			}
 			String extension = Url.substring(Url.length() - 4, Url.length());
-			if (extension.equalsIgnoreCase(".ogg") || extension.equalsIgnoreCase(".wav") || extension.matches(".*[mM][iI][dD][iI]?$")) {
+			if (extension.equalsIgnoreCase(".ogg") || extension.equalsIgnoreCase(".wav") || extension.equalsIgnoreCase(".mp3") || extension.matches(".*[mM][iI][dD][iI]?$")) {
 				if (location == null || location.getWorld().equals(target.getWorld())) {
 					if (!soundEffect) {
 						BackgroundMusicEvent event = new BackgroundMusicEvent(Url, volumePercent, target);

--- a/src/main/java/org/getspout/spoutapi/block/design/GenericBlockDesign.java
+++ b/src/main/java/org/getspout/spoutapi/block/design/GenericBlockDesign.java
@@ -20,12 +20,10 @@
 package org.getspout.spoutapi.block.design;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.util.BlockVector;
-
 import org.getspout.spoutapi.io.SpoutInputStream;
 import org.getspout.spoutapi.io.SpoutOutputStream;
 import org.getspout.spoutapi.packet.PacketUtil;

--- a/src/main/java/org/getspout/spoutapi/event/spout/SpoutcraftBuildSetEvent.java
+++ b/src/main/java/org/getspout/spoutapi/event/spout/SpoutcraftBuildSetEvent.java
@@ -19,11 +19,9 @@
  */
 package org.getspout.spoutapi.event.spout;
 
-import org.getspout.spoutapi.player.SpoutPlayer;
-
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.getspout.spoutapi.player.SpoutPlayer;
 
 public class SpoutcraftBuildSetEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/getspout/spoutapi/material/item/GenericCustomItem.java
+++ b/src/main/java/org/getspout/spoutapi/material/item/GenericCustomItem.java
@@ -19,12 +19,12 @@
  */
 package org.getspout.spoutapi.material.item;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.bukkit.Bukkit;
 import org.bukkit.block.BlockFace;
 import org.bukkit.plugin.Plugin;
-
 import org.getspout.spoutapi.Spout;
 import org.getspout.spoutapi.SpoutManager;
 import org.getspout.spoutapi.block.SpoutBlock;
@@ -84,11 +84,24 @@ public class GenericCustomItem extends GenericItem implements CustomItem, SpoutP
 
 	@Override
 	public CustomItem setTexture(String texture) {
-		SpoutManager.getFileManager().addToCache(plugin, texture);
-		this.texture = texture;
+		this.setTexture(texture, true);
 		return this;
 	}
 
+	public CustomItem setTexture(String texture, boolean addToCache) {
+		if (addToCache == true) {
+			SpoutManager.getFileManager().addToCache(plugin, texture);
+		}
+		this.texture = texture;
+		return this;
+	}
+	
+	public CustomItem setTexture(File texture) {
+		SpoutManager.getFileManager().addToCache(plugin, texture);
+		this.setTexture(texture.getName(), false);
+		return this;
+	}
+	
 	@Override
 	public String getTexture() {
 		if (texture == null) {


### PR DESCRIPTION
I found that my custom item textures were getting destroyed rendering my custom items as flint. Found this to be because the setTexture of GenericCustomItem was calling addToCache(String), which was adding my textures to the cache again from a URL standpoint, where as my textures are loaded from disc using addToCache(File). 

This was causing my custom item textures to get blanked out rendering them as flint. To solve this I added a method setTexture(File) which I can pass a File reference, and the method can use the appropriate addToCache this way.

Also I removed several unused imports.
