### PR TITLE
Add missing tail accessory enum.

### DIFF
--- a/src/main/java/org/getspout/spoutapi/player/accessories/AccessoryType.java
+++ b/src/main/java/org/getspout/spoutapi/player/accessories/AccessoryType.java
@@ -28,7 +28,8 @@ public enum AccessoryType {
 	BRACELET(3),
 	WINGS(4),
 	EARS(5),
-	SUNGLASSES(6);
+	SUNGLASSES(6),
+	TAIL(7);
 	private final int id;
 	private static Map<Integer, AccessoryType> types = new HashMap<Integer, AccessoryType>();
 


### PR DESCRIPTION
@znickq wanted this, but I take all the credit.
