### PR TITLE
Remove stack trace when we cannot set the packet overflow limit

### DIFF
--- a/src/main/java/org/getspout/spout/SpoutPlayerConnection.java
+++ b/src/main/java/org/getspout/spout/SpoutPlayerConnection.java
@@ -73,7 +73,6 @@ public class SpoutPlayerConnection extends PlayerConnection {
 			int size = (Integer) y.get(this.networkManager);
 			y.set(this.networkManager, size - 1024 * 1024 * 9);
 		} catch (Exception e) {
-			e.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
This field is non crucial, and as such when it is failed to be set, it can safely be ignored. It will generally only fail in a scenario where the variable would have no effect anyway.
